### PR TITLE
feat: Enable automatic GitHub PR creation

### DIFF
--- a/odyssey/README.md
+++ b/odyssey/README.md
@@ -164,6 +164,33 @@ Odyssey can connect to Ollama-hosted language models, supporting both a local in
     ```
     Replace `your-remote-ollama-ip` with the actual IP address of your remote Ollama server. If you're only using a local instance, you can leave `OLLAMA_REMOTE_URL` blank or comment it out.
 
+### GitHub Integration for Pull Requests
+For Odyssey to automatically create Pull Requests (PRs) for its proposed code changes, you need to configure GitHub access:
+
+1.  **Generate a GitHub Personal Access Token (PAT):**
+    *   Go to your GitHub settings: [github.com/settings/tokens](https://github.com/settings/tokens).
+    *   Click "Generate new token" (select Classic or Fine-grained).
+        *   **Classic Token:** Give it a descriptive name (e.g., "odyssey-agent-pr"). Select the expiration that suits you. For scopes, you need:
+            *   `repo` (Full control of private repositories) if your target repository is private.
+            *   `public_repo` (Access public repositories) if your target repository is public and you only need to operate on public aspects. For creating PRs, `repo` is generally safer if you might work with private repos or need full capabilities.
+        *   **Fine-grained Token:** Select resource owner, then choose repository access (all or select). For "Repository permissions", you will need at least:
+            *   `Contents: Read and write`
+            *   `Pull requests: Read and write`
+    *   Click "Generate token" and **copy the token immediately**. You won't be able to see it again.
+
+2.  **Set Environment Variables:**
+    In your `.env` file, add the following (using the token you just copied):
+    ```env
+    GITHUB_TOKEN="your_copied_github_personal_access_token"
+    GITHUB_REPO_OWNER="your_github_username_or_organization_name" # e.g., "octocat"
+    GITHUB_REPO_NAME="your_repository_name" # e.g., "odyssey"
+    ```
+    *   `GITHUB_TOKEN`: The PAT you generated.
+    *   `GITHUB_REPO_OWNER`: The username of the account or the name of the organization that owns the repository where PRs will be created.
+    *   `GITHUB_REPO_NAME`: The name of the repository itself.
+
+With these settings, `SelfModifier` will be able to use the GitHub API to create branches and open pull requests.
+
 **API Usage (`/llm/ask`):**
 
 You can send prompts to the LLM via the `/api/v1/llm/ask` endpoint.

--- a/odyssey/agent/main.py
+++ b/odyssey/agent/main.py
@@ -75,6 +75,9 @@ class AppSettings(BaseSettings):
     # SelfModifier settings
     repo_path: str = "." # Default to current directory, can be overridden by env
     SELF_MOD_APPROVAL_MODE: str = "manual" # Options: 'manual' (default), 'auto'
+    GITHUB_TOKEN: Optional[str] = None
+    GITHUB_REPO_OWNER: Optional[str] = None
+    GITHUB_REPO_NAME: Optional[str] = None
 
     # Sandbox settings
     SANDBOX_HEALTH_CHECK_ENDPOINT: str = "/health"
@@ -171,8 +174,14 @@ async def lifespan(app_instance: FastAPI): # Renamed app to app_instance to avoi
     get_tool_manager_dependency.instance = app_state.tool_manager
 
     # SelfModifier
-    app_state.self_modifier = SelfModifier(repo_path=app_state.settings.repo_path)
-    logger.info(f"SelfModifier initialized for repo path: {app_state.settings.repo_path}")
+    app_state.self_modifier = SelfModifier(
+        repo_path=app_state.settings.repo_path,
+        github_token=app_state.settings.GITHUB_TOKEN,
+        repo_owner=app_state.settings.GITHUB_REPO_OWNER,
+        repo_name=app_state.settings.GITHUB_REPO_NAME
+        # sandbox_manager will be set later if needed by SelfModifier, or passed here
+    )
+    logger.info(f"SelfModifier initialized for repo path: {app_state.settings.repo_path}, Owner: {app_state.settings.GITHUB_REPO_OWNER}, Repo: {app_state.settings.GITHUB_REPO_NAME}")
     get_self_modifier_dependency.instance = app_state.self_modifier
 
     # logger.info("Placeholder: Initialize Planner")

--- a/odyssey/config/secrets.env
+++ b/odyssey/config/secrets.env
@@ -4,8 +4,18 @@
 
 # Example API Keys
 # OPENAI_API_KEY="your_openai_api_key_here"
-# GITHUB_TOKEN="your_github_personal_access_token_here"
 # GOOGLE_CALENDAR_API_KEY="your_google_calendar_api_key"
+
+# --- GitHub Integration (for SelfModifier PRs) ---
+# Personal Access Token (PAT) for GitHub API.
+# Required for creating pull requests. Generate from GitHub settings.
+# Needs 'repo' scope for private repositories, 'public_repo' for public.
+GITHUB_TOKEN=""
+# The owner of the GitHub repository (username or organization).
+GITHUB_REPO_OWNER=""
+# The name of the GitHub repository.
+GITHUB_REPO_NAME=""
+
 
 # Database Credentials (if not using local defaults)
 # DB_PASSWORD="your_database_password"

--- a/odyssey/config/settings.yaml
+++ b/odyssey/config/settings.yaml
@@ -47,6 +47,12 @@ memory:
 # Logging
 logging:
   level: "INFO" # DEBUG, INFO, WARNING, ERROR, CRITICAL
+
+# GitHub Integration (for SelfModifier PRs)
+# These are typically set in .env file and loaded by AppSettings
+# GITHUB_TOKEN: "your_github_personal_access_token"
+# GITHUB_REPO_OWNER: "your_github_username_or_org"
+# GITHUB_REPO_NAME: "your_repository_name"
   file: "logs/odyssey_agent.log"
   format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 

--- a/odyssey/requirements.txt
+++ b/odyssey/requirements.txt
@@ -22,6 +22,7 @@ celery[redis] # Includes redis dependency for broker/backend with Valkey (Redis 
 chromadb # As per docker-compose.yml and MemoryManager intent
 # qdrant-client
 sentence-transformers # For generating embeddings for vector stores (needed by MemoryManager)
+PyGithub # For GitHub API interactions
 
 # Observability
 langfuse # As per docker-compose.yml and MemoryManager intent

--- a/tests/agent/test_self_modifier.py
+++ b/tests/agent/test_self_modifier.py
@@ -68,5 +68,208 @@ class TestSelfModifierSandbox(unittest.TestCase):
         self.assertIn("does not support 'run_validation_in_docker'", output_log)
 
 
+class TestSelfModifierGitHub(unittest.TestCase):
+    def setUp(self):
+        # Mock os.path.isdir to always return True, simulating a git repo
+        self.patch_isdir = patch('odyssey.agent.self_modifier.os.path.isdir', return_value=True)
+        self.mock_os_isdir = self.patch_isdir.start()
+
+        # Mock os.path.abspath
+        self.patch_abspath = patch('odyssey.agent.self_modifier.os.path.abspath', return_value="/fake/repo")
+        self.mock_os_abspath = self.patch_abspath.start()
+
+        # Mock _run_git_command for general git operations not under test
+        self.patch_run_git = patch('odyssey.agent.self_modifier.SelfModifier._run_git_command')
+        self.mock_run_git_command = self.patch_run_git.start()
+        # Default behavior for git calls not specific to a test
+        self.mock_run_git_command.return_value = ("output", "", 0)
+
+
+    def tearDown(self):
+        self.patch_isdir.stop()
+        self.patch_abspath.stop()
+        self.patch_run_git.stop()
+        patch.stopall() # Stops any other patches that might have been started
+
+    @patch('odyssey.agent.self_modifier.Github')
+    def test_init_with_github_credentials(self, MockGithub):
+        """Test SelfModifier initialization with GitHub credentials."""
+        mock_github_instance = MockGithub.return_value
+
+        modifier = SelfModifier(
+            repo_path=".",
+            github_token="fake_token",
+            repo_owner="testowner",
+            repo_name="testrepo"
+        )
+        MockGithub.assert_called_once_with("fake_token")
+        self.assertEqual(modifier.github_client, mock_github_instance)
+        self.assertEqual(modifier.repo_owner, "testowner")
+        self.assertEqual(modifier.repo_name, "testrepo")
+
+    def test_init_without_github_credentials(self):
+        """Test SelfModifier initialization without GitHub credentials."""
+        modifier = SelfModifier(repo_path=".")
+        self.assertIsNone(modifier.github_client)
+        self.assertIsNone(modifier.repo_owner)
+        self.assertIsNone(modifier.repo_name)
+
+    @patch('odyssey.agent.self_modifier.Github')
+    def test_open_pr_success(self, MockGithub):
+        """Test successful PR opening."""
+        mock_github_instance = MockGithub.return_value
+        mock_repo = MagicMock()
+        mock_github_instance.get_repo.return_value = mock_repo
+
+        mock_pr = MagicMock()
+        mock_pr.html_url = "https://github.com/testowner/testrepo/pull/1"
+        mock_pr.number = 1
+        mock_pr.id = 12345
+        mock_repo.create_pull.return_value = mock_pr
+        mock_repo.get_pulls.return_value = [] # No existing PRs
+
+        modifier = SelfModifier(
+            github_token="fake_token", repo_owner="testowner", repo_name="testrepo"
+        )
+
+        # Mock git log command for PR title
+        self.mock_run_git_command.side_effect = lambda cmd_parts, **kwargs: ("Test PR Title from commit\nMore details", "", 0) if cmd_parts[:3] == ["log", "-1", "--pretty=%B"] else ("output", "", 0)
+
+
+        pr_url, pr_number, error = modifier.open_pr(
+            branch="feature/test-branch", title=None, body="Test PR body", base_branch="main"
+        )
+
+        self.assertEqual(pr_url, "https://github.com/testowner/testrepo/pull/1")
+        self.assertEqual(pr_number, 1)
+        self.assertIsNone(error)
+        mock_github_instance.get_repo.assert_called_once_with("testowner/testrepo")
+        mock_repo.create_pull.assert_called_once_with(
+            title="Test PR Title from commit", # Title from mocked git log
+            body="Test PR body",
+            head="feature/test-branch",
+            base="main"
+        )
+        mock_repo.get_pulls.assert_called_once_with(state='open', head='testowner:feature/test-branch')
+
+
+    @patch('odyssey.agent.self_modifier.Github')
+    def test_open_pr_already_exists(self, MockGithub):
+        """Test PR opening when a PR for the branch already exists."""
+        mock_github_instance = MockGithub.return_value
+        mock_repo = MagicMock()
+        mock_github_instance.get_repo.return_value = mock_repo
+
+        mock_existing_pr = MagicMock()
+        mock_existing_pr.html_url = "https://github.com/testowner/testrepo/pull/existing"
+        mock_existing_pr.number = 99
+        mock_existing_pr.head.ref = "feature/existing-pr-branch" # Matches head in get_pulls
+        mock_existing_pr.base.ref = "main" # Matches base_branch
+
+        # Simulate get_pulls finding an existing PR
+        mock_repo.get_pulls.return_value = [mock_existing_pr]
+
+        modifier = SelfModifier(
+            github_token="fake_token", repo_owner="testowner", repo_name="testrepo"
+        )
+
+        pr_url, pr_number, error = modifier.open_pr(
+            branch="feature/existing-pr-branch", title="New PR Title", base_branch="main"
+        )
+
+        self.assertEqual(pr_url, mock_existing_pr.html_url)
+        self.assertEqual(pr_number, mock_existing_pr.number)
+        self.assertIn("PR already exists", error)
+        mock_repo.create_pull.assert_not_called() # Should not attempt to create new PR
+        mock_repo.get_pulls.assert_called_once_with(state='open', head='testowner:feature/existing-pr-branch')
+
+
+    @patch('odyssey.agent.self_modifier.Github')
+    def test_open_pr_github_api_error(self, MockGithub):
+        """Test PR opening when GitHub API call fails."""
+        from github import GithubException # Import locally for patching
+
+        mock_github_instance = MockGithub.return_value
+        mock_repo = MagicMock()
+        mock_github_instance.get_repo.return_value = mock_repo
+        mock_repo.get_pulls.return_value = [] # No existing PRs
+
+        # Simulate a GithubException during create_pull
+        mock_repo.create_pull.side_effect = GithubException(
+            status=422, data={"message": "Validation Failed", "errors": [{"message": "A pull request already exists for testowner:feature/api-error-branch."}]}, headers={}
+        )
+
+        modifier = SelfModifier(
+            github_token="fake_token", repo_owner="testowner", repo_name="testrepo"
+        )
+
+        pr_url, pr_number, error = modifier.open_pr(
+            branch="feature/api-error-branch", title="Error PR", base_branch="main"
+        )
+
+        self.assertIsNone(pr_url)
+        self.assertIsNone(pr_number)
+        self.assertIsNotNone(error)
+        self.assertIn("Validation Failed", error)
+        self.assertIn("Likely PR already exists", error) # Test the specific error parsing
+
+    def test_open_pr_no_github_client(self):
+        """Test PR opening when GitHub client is not initialized."""
+        modifier = SelfModifier(repo_path=".") # No token, owner, name
+        pr_url, pr_number, error = modifier.open_pr(
+            branch="feature/no-client-branch", title="No Client PR", base_branch="main"
+        )
+        self.assertIsNone(pr_url)
+        self.assertIsNone(pr_number)
+        self.assertIsNotNone(error)
+        self.assertIn("PyGithub client not initialized", error)
+
+    @patch('odyssey.agent.self_modifier.SelfModifier.open_pr')
+    def test_propose_code_changes_calls_open_pr(self, mock_open_pr):
+        """Test that propose_code_changes calls open_pr and returns its results."""
+        modifier = SelfModifier(
+            github_token="fake_token", repo_owner="testowner", repo_name="testrepo"
+        )
+        # Mock _run_git_command to simulate git operations succeeding
+        # Specific mock for rev-parse
+        def mock_git_command_for_propose(cmd_parts, **kwargs):
+            if cmd_parts == ["rev-parse", "--abbrev-ref", "HEAD"]:
+                return ("main", "", 0) # Current branch
+            # For other commands like add, commit, push
+            return ("mock git output", "", 0)
+
+        self.mock_run_git_command.side_effect = mock_git_command_for_propose
+
+        # Mock checkout_branch to always succeed
+        modifier.checkout_branch = MagicMock(return_value=True)
+
+        # Set return value for the mocked open_pr
+        mock_open_pr.return_value = ("http://pr.url/1", 1, None)
+
+        files_content = {"file.py": "print('hello')"}
+        commit_message = "Test commit for PR"
+        proposal_id = "prop-123"
+
+        branch_name, pr_url, pr_number, pr_error = modifier.propose_code_changes(
+            files_content, commit_message, proposal_id=proposal_id
+        )
+
+        self.assertIsNotNone(branch_name) # Branch name should be generated
+        # Example branch name: "proposal/prop-123_test-commit-for-pr"
+        expected_branch_suffix = f"{proposal_id}_test-commit-for-pr" # Simplified check
+        self.assertTrue(branch_name.startswith("proposal/"))
+        self.assertIn(expected_branch_suffix, branch_name)
+
+        self.assertEqual(pr_url, "http://pr.url/1")
+        self.assertEqual(pr_number, 1)
+        self.assertIsNone(pr_error)
+
+        mock_open_pr.assert_called_once()
+        args, kwargs = mock_open_pr.call_args
+        self.assertEqual(kwargs['branch'], branch_name)
+        self.assertEqual(kwargs['title'], f"Proposal {proposal_id}: {commit_message.splitlines()[0]}")
+        self.assertIn(f"Automated PR for proposal ID: {proposal_id}", kwargs['body'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Integrates PyGithub to allow Odyssey to programmatically open pull requests for self-modifications.

Key changes:
- Added PyGithub to requirements.
- Updated SelfModifier to use PyGithub for creating PRs.
  - `__init__` now takes GitHub repo owner, name, and token.
  - `open_pr` method creates PRs using the GitHub API.
  - `propose_code_changes` now calls `open_pr` and returns PR details.
- Updated MemoryManager's `self_modification_log` table and related methods to store PR URL, ID, and status.
- Added configuration (`AppSettings`, `secrets.env`, `README.md`) for GitHub token, repo owner, and repo name.
- Enhanced error handling and logging for GitHub API interactions.
- Added/updated unit tests for SelfModifier and MemoryManager to cover new PR functionality.